### PR TITLE
Switch from arrays to var args

### DIFF
--- a/src/me/winterguardian/easyscoreboards/ScoreboardUtil.java
+++ b/src/me/winterguardian/easyscoreboards/ScoreboardUtil.java
@@ -76,7 +76,7 @@ public class ScoreboardUtil
 
 	}
 
-	public static boolean unrankedSidebarDisplay(Player p, String[] elements)
+	public static boolean unrankedSidebarDisplay(Player p, String... elements)
 	{
 		elements = cutUnranked(elements);
 
@@ -144,7 +144,7 @@ public class ScoreboardUtil
 		return true;
 	}
 
-	public static boolean unrankedSidebarDisplay(Collection<Player> players, String[] elements, Scoreboard board)
+	public static boolean unrankedSidebarDisplay(Collection<Player> players, Scoreboard board, String... elements)
 	{
 		try
 		{


### PR DESCRIPTION
Allows developers to have cleaner code. Really no real reason to forcefully use `String[]` VS var args.
